### PR TITLE
Grpc fiber router integration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -170,9 +170,9 @@ type ProxyConfig struct {
 	ComponentConfig
 	Endpoint string   `json:"endpoint" required:"true"`
 	Timeout  Duration `json:"timeout"`
-	Protocol string   `json:"protocol"`
-	Service  string   `json:"service"`
-	Method   string   `json:"method"`
+	Protocol string   `json:"protocol,omitempty"`
+	Service  string   `json:"service,omitempty"`
+	Method   string   `json:"method,omitempty"`
 }
 
 func (c *ProxyConfig) initComponent() (fiber.Component, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -70,11 +70,11 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 func (r Routes) Routes() (map[string]fiber.Component, error) {
 	routes := make(map[string]fiber.Component)
 	for _, routeConfig := range r {
-		if route, err := routeConfig.initComponent(); err != nil {
+		route, err := routeConfig.initComponent()
+		if err != nil {
 			return nil, err
-		} else {
-			routes[route.ID()] = route
 		}
+		routes[route.ID()] = route
 	}
 	return routes, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -180,9 +180,13 @@ type ProxyConfig struct {
 	ComponentConfig
 	Endpoint string   `json:"endpoint" required:"true"`
 	Timeout  Duration `json:"timeout"`
-	Protocol string   `json:"protocol,omitempty"`
-	Service  string   `json:"service,omitempty"`
-	Method   string   `json:"method,omitempty"`
+	Protocol string   `json:"protocol"`
+	GrpcConfig
+}
+
+type GrpcConfig struct {
+	Service string `json:"service,omitempty"`
+	Method  string `json:"method,omitempty"`
 }
 
 func (c *ProxyConfig) initComponent() (fiber.Component, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -67,15 +67,16 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 }
 
 // Routes takes in an object of type Routes and returns a map of each route's ID and the route
-func (r Routes) Routes() map[string]fiber.Component {
+func (r Routes) Routes() (map[string]fiber.Component, error) {
 	routes := make(map[string]fiber.Component)
 	for _, routeConfig := range r {
 		if route, err := routeConfig.initComponent(); err != nil {
+			return nil, err
 		} else {
 			routes[route.ID()] = route
 		}
 	}
-	return routes
+	return routes, nil
 }
 
 // MultiRouteConfig is used to parse the configuration for a MultiRouteComponent
@@ -112,7 +113,11 @@ func (c *RouterConfig) initComponent() (fiber.Component, error) {
 	default:
 		return nil, fmt.Errorf("unknown router type: [%s]", c.Type)
 	}
-	router.SetRoutes(c.Routes.Routes())
+	routes, err := c.Routes.Routes()
+	if err != nil {
+		return nil, err
+	}
+	router.SetRoutes(routes)
 
 	strategy, err := c.Strategy.Strategy()
 	if err != nil {
@@ -149,7 +154,12 @@ func (c *FanInConfig) FanIn() (fiber.FanIn, error) {
 
 func (c *CombinerConfig) initComponent() (fiber.Component, error) {
 	combiner := fiber.NewCombiner(c.ID)
-	combiner.SetRoutes(c.Routes.Routes())
+
+	routes, err := c.Routes.Routes()
+	if err != nil {
+		return nil, err
+	}
+	combiner.SetRoutes(routes)
 
 	fanIn, err := c.FanIn.FanIn()
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,7 +112,7 @@ func TestFromConfig(t *testing.T) {
 		{
 			name:           "grpc proxy",
 			configPath:     "../internal/testdata/config/invalid_grpc_proxy.yaml",
-			expectedErrMsg: "fiber: grpc dispatcher: missing config (endpoint/service/method/response-proto)",
+			expectedErrMsg: "fiber: grpc dispatcher: missing config (endpoint/service/method)",
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/dynamicpb"
 )
@@ -93,37 +94,47 @@ func TestFromConfig(t *testing.T) {
 	grpcProxy := fiber.NewProxy(nil, grpcCaller)
 
 	tests := []struct {
-		name       string
-		configPath string
-		want       fiber.Component
+		name              string
+		configPath        string
+		expectedComponent fiber.Component
+		expectedErrMsg    string
 	}{
 		{
-			name:       "http proxy",
-			configPath: "../internal/testdata/config/http_proxy.yaml",
-			want:       httpProxy,
+			name:              "http proxy",
+			configPath:        "../internal/testdata/config/http_proxy.yaml",
+			expectedComponent: httpProxy,
 		},
 		{
-			name:       "grpc proxy",
-			configPath: "../internal/testdata/config/grpc_proxy.yaml",
-			want:       grpcProxy,
+			name:              "grpc proxy",
+			configPath:        "../internal/testdata/config/grpc_proxy.yaml",
+			expectedComponent: grpcProxy,
+		},
+		{
+			name:           "grpc proxy",
+			configPath:     "../internal/testdata/config/invalid_grpc_proxy.yaml",
+			expectedErrMsg: "fiber: grpc dispatcher: missing config (endpoint/service/method/response-proto)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := config.InitComponentFromConfig(tt.configPath)
-			assert.NoError(t, err)
-			assert.True(t,
-				cmp.Equal(tt.want, got,
-					cmpopts.IgnoreUnexported(grpc.ClientConn{}, dynamicpb.Message{}),
-					cmp.AllowUnexported(
-						fiber.BaseComponent{},
-						fiber.Proxy{},
-						fiber.Caller{},
-						fibergrpc.Dispatcher{},
-						fiberhttp.Dispatcher{}),
-				),
-				"config not equal to expected")
+			if tt.expectedErrMsg == "" {
+				require.NoError(t, err)
+				assert.True(t,
+					cmp.Equal(tt.expectedComponent, got,
+						cmpopts.IgnoreUnexported(grpc.ClientConn{}, dynamicpb.Message{}),
+						cmp.AllowUnexported(
+							fiber.BaseComponent{},
+							fiber.Proxy{},
+							fiber.Caller{},
+							fibergrpc.Dispatcher{},
+							fiberhttp.Dispatcher{}),
+					),
+					"config not equal to expected")
+			} else {
+				assert.Equal(t, tt.expectedErrMsg, err.Error())
+			}
 		})
 	}
 }

--- a/grpc/dispatcher.go
+++ b/grpc/dispatcher.go
@@ -92,7 +92,7 @@ func NewDispatcher(config DispatcherConfig) (*Dispatcher, error) {
 	if config.Endpoint == "" || config.Service == "" || config.Method == "" {
 		return nil, fiberError.ErrInvalidInput(
 			protocol.GRPC,
-			errors.New("grpc dispatcher: missing config (endpoint/service/method/response-proto)"))
+			errors.New("grpc dispatcher: missing config (endpoint/service/method)"))
 	}
 
 	conn, err := grpc.DialContext(context.Background(), config.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/grpc/dispatcher_test.go
+++ b/grpc/dispatcher_test.go
@@ -97,7 +97,7 @@ func TestNewDispatcher(t *testing.T) {
 			expected: nil,
 			expectedErr: fiberError.ErrInvalidInput(
 				protocol.GRPC,
-				errors.New("grpc dispatcher: missing config (endpoint/service/method/response-proto)")),
+				errors.New("grpc dispatcher: missing config (endpoint/service/method)")),
 		},
 		{
 			name: "empty service",
@@ -108,7 +108,7 @@ func TestNewDispatcher(t *testing.T) {
 			expected: nil,
 			expectedErr: fiberError.ErrInvalidInput(
 				protocol.GRPC,
-				errors.New("grpc dispatcher: missing config (endpoint/service/method/response-proto)")),
+				errors.New("grpc dispatcher: missing config (endpoint/service/method)")),
 		},
 		{
 			name: "empty method",
@@ -119,7 +119,7 @@ func TestNewDispatcher(t *testing.T) {
 			expected: nil,
 			expectedErr: fiberError.ErrInvalidInput(
 				protocol.GRPC,
-				errors.New("grpc dispatcher: missing config (endpoint/service/method/response-proto)")),
+				errors.New("grpc dispatcher: missing config (endpoint/service/method)")),
 		},
 		{
 			name: "invalid endpoint",

--- a/internal/testdata/config/invalid_grpc_proxy.yaml
+++ b/internal/testdata/config/invalid_grpc_proxy.yaml
@@ -1,0 +1,5 @@
+type: PROXY
+id: proxy_name
+timeout: "20s"
+endpoint: "localhost:50555"
+protocol: "grpc"


### PR DESCRIPTION
### Description
Minor bugfix for grpc fiber

### Changes

- Handle unhandled error at [config.go](https://github.com/gojek/fiber/blob/main/config/config.go#L73)
- Add negative test case for the above
- Add `omitempty` to proxy struct's `protocol, service, method` field, as these json fields are not required in HTTP setting