### PR TITLE
Eliminate grpc dispatch proto marshaling overhead with Codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ traffic mixers from a set of composable abstract network components.
 
 Core components of fiber are transport agnostic, however, there is 
 Go's `net/http`-based implementation provided in [fiber/http](http) package 
-and a grpc implementation using server reflection in [fiber/grpc](grpc).
+and a grpc implementation in [fiber/grpc](grpc).
 
-The grpc implementation will return a [dynamicpb message](https://pkg.go.dev/google.golang.org/protobuf/types/dynamicpb) 
-and it is expected that the client [marshal](https://pkg.go.dev/github.com/golang/protobuf/proto#Marshal) the message and unmarshall into the intended proto response.
+The grpc implementation will use the byte payload from the request and response using a custom codec to minimize marshaling overhead.
+It is expected that the client [marshal](https://pkg.go.dev/github.com/golang/protobuf/proto#Marshal) the message and unmarshall into the intended proto response.
 
 ## Usage
 

--- a/cached_payload.go
+++ b/cached_payload.go
@@ -11,6 +11,6 @@ type CachedPayload struct {
 }
 
 // Payload returns the cached []byte contents
-func (b *CachedPayload) Payload() interface{} {
+func (b *CachedPayload) Payload() []byte {
 	return b.data
 }

--- a/eager_router_test.go
+++ b/eager_router_test.go
@@ -263,7 +263,7 @@ func TestEagerRouter_Dispatch(t *testing.T) {
 
 			assert.Equal(t, len(tt.expected), len(received), tt.name)
 			for i := 0; i < len(tt.expected); i++ {
-				assert.Equal(t, string(tt.expected[i].Payload().([]byte)), string(received[i].Payload().([]byte)), tt.name)
+				assert.Equal(t, string(tt.expected[i].Payload()), string(received[i].Payload()), tt.name)
 				assert.Equal(t, tt.expected[i].StatusCode(), received[i].StatusCode(), tt.name)
 			}
 			strategy.AssertExpectations(t)

--- a/example/simplegrpc/main.go
+++ b/example/simplegrpc/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/gojek/fiber"
@@ -78,7 +77,6 @@ func main() {
 	resp, ok := <-component.Dispatch(context.Background(), req).Iter()
 	if ok {
 		if resp.StatusCode() == int(codes.OK) {
-			log.Print(resp.Payload())
 			responseProto := &testproto.PredictValuesResponse{}
 			err := proto.Unmarshal(resp.Payload(), responseProto)
 			if err != nil {
@@ -86,7 +84,7 @@ func main() {
 			}
 			log.Print(responseProto.String())
 		} else {
-			log.Fatalf(fmt.Sprintf("%s", resp.Payload()))
+			log.Fatalf(string(resp.Payload()))
 		}
 	} else {
 		log.Fatalf("fail to receive response queue")

--- a/example/simplegrpc/main.go
+++ b/example/simplegrpc/main.go
@@ -61,35 +61,26 @@ func main() {
 		"route-b": proxy2,
 	})
 
-	var req = &grpc.Request{
-		Message: &testproto.PredictValuesRequest{
-			PredictionRows: []*testproto.PredictionRow{
-				{
-					RowId: "1",
-				},
-				{
-					RowId: "2",
-				},
+	bytePayload, _ := proto.Marshal(&testproto.PredictValuesRequest{
+		PredictionRows: []*testproto.PredictionRow{
+			{
+				RowId: "1",
+			},
+			{
+				RowId: "2",
 			},
 		},
+	})
+	var req = &grpc.Request{
+		Message: bytePayload,
 	}
 
 	resp, ok := <-component.Dispatch(context.Background(), req).Iter()
 	if ok {
 		if resp.StatusCode() == int(codes.OK) {
 			log.Print(resp.Payload())
-
-			//values can be retrieved using protoReflect or marshalled into proto
-			payload, ok := resp.Payload().(proto.Message)
-			if !ok {
-				log.Fatalf("fail to convert response to proto")
-			}
-			payloadByte, err := proto.Marshal(payload)
-			if err != nil {
-				log.Fatalf("fail to marshal to proto")
-			}
 			responseProto := &testproto.PredictValuesResponse{}
-			err = proto.Unmarshal(payloadByte, responseProto)
+			err := proto.Unmarshal(resp.Payload(), responseProto)
 			if err != nil {
 				log.Fatalf("fail to unmarshal to proto")
 			}

--- a/example/simplegrpcfromconfig/main.go
+++ b/example/simplegrpcfromconfig/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/gojek/fiber/config"
@@ -49,8 +48,6 @@ func main() {
 	resp, ok := <-component.Dispatch(context.Background(), req).Iter()
 	if ok {
 		if resp.StatusCode() == int(codes.OK) {
-			log.Print(resp.Payload())
-
 			//values can be retrieved using protoReflect or marshalled into proto
 			responseProto := &testproto.PredictValuesResponse{}
 			err = proto.Unmarshal(resp.Payload(), responseProto)
@@ -59,7 +56,7 @@ func main() {
 			}
 			log.Print(responseProto.String())
 		} else {
-			log.Fatalf(fmt.Sprintf("%s", resp.Payload()))
+			log.Fatalf(string(resp.Payload()))
 		}
 	} else {
 		log.Fatalf("fail to receive response queue")

--- a/example/simplegrpcfromconfig/main.go
+++ b/example/simplegrpcfromconfig/main.go
@@ -32,18 +32,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("\nerror: %v\n", err)
 	}
-
-	var req = &grpc.Request{
-		Message: &testproto.PredictValuesRequest{
-			PredictionRows: []*testproto.PredictionRow{
-				{
-					RowId: "1",
-				},
-				{
-					RowId: "2",
-				},
+	bytePayload, _ := proto.Marshal(&testproto.PredictValuesRequest{
+		PredictionRows: []*testproto.PredictionRow{
+			{
+				RowId: "1",
+			},
+			{
+				RowId: "2",
 			},
 		},
+	})
+	var req = &grpc.Request{
+		Message: bytePayload,
 	}
 
 	resp, ok := <-component.Dispatch(context.Background(), req).Iter()
@@ -52,16 +52,8 @@ func main() {
 			log.Print(resp.Payload())
 
 			//values can be retrieved using protoReflect or marshalled into proto
-			payload, ok := resp.Payload().(proto.Message)
-			if !ok {
-				log.Fatalf("fail to convert response to proto")
-			}
-			payloadByte, err := proto.Marshal(payload)
-			if err != nil {
-				log.Fatalf("fail to marshal to proto")
-			}
 			responseProto := &testproto.PredictValuesResponse{}
-			err = proto.Unmarshal(payloadByte, responseProto)
+			err = proto.Unmarshal(resp.Payload(), responseProto)
 			if err != nil {
 				log.Fatalf("fail to unmarshal to proto")
 			}

--- a/grpc/codec.go
+++ b/grpc/codec.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CodecName is the name registered for the proto compressor.
-const CodecName = "FiberCodec"
+const codecName = "fiber"
 
 // FiberCodec is a custom codec to prevent marshaling and unmarshalling
 // when unnecessary, base on the inputs
@@ -37,7 +37,7 @@ func (fc *FiberCodec) Unmarshal(data []byte, v interface{}) error {
 }
 
 func (*FiberCodec) Name() string {
-	return CodecName
+	return codecName
 }
 
 func (fc *FiberCodec) getDefaultCodec() encoding.Codec {

--- a/grpc/codec.go
+++ b/grpc/codec.go
@@ -1,8 +1,9 @@
 package grpc
 
 import (
-	"google.golang.org/grpc/encoding"
 	"io"
+
+	"google.golang.org/grpc/encoding"
 )
 
 // CodecName is the name registered for the proto compressor.

--- a/grpc/codec.go
+++ b/grpc/codec.go
@@ -1,0 +1,43 @@
+package grpc
+
+import (
+	"fmt"
+	"io"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// CodecName is the name registered for the proto compressor.
+const CodecName = "FiberCodec"
+
+type FiberCodec struct{}
+
+func (FiberCodec) Marshal(v interface{}) ([]byte, error) {
+	b, ok := v.([]byte)
+	if ok {
+		return b, nil
+	}
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message or []byte", v)
+	}
+	return proto.Marshal(vv)
+}
+
+func (FiberCodec) Unmarshal(data []byte, v interface{}) error {
+
+	myType, ok := v.(io.Writer)
+	if ok {
+		myType.Write(data)
+		return nil
+	}
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Errorf("failed to marshal, message is %T, want proto.Message or io.writer", v)
+	}
+	return proto.Unmarshal(data, vv)
+}
+
+func (FiberCodec) Name() string {
+	return CodecName
+}

--- a/grpc/dispatcher.go
+++ b/grpc/dispatcher.go
@@ -1,10 +1,10 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"go.uber.org/zap/buffer"
 	"time"
 
 	"github.com/gojek/fiber"
@@ -57,8 +57,12 @@ func (d *Dispatcher) Do(request fiber.Request) fiber.Response {
 	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, grpcRequest.Metadata)
 
-	response := new(buffer.Buffer)
+	response := new(bytes.Buffer)
 	var responseHeader metadata.MD
+
+	// Dispatcher will send both request and payload as bytes, with the use of codec
+	// to prevent marshaling. The codec content type will be sent with request and
+	// the server will attempt to unmarshal with the codec.
 	err := d.conn.Invoke(
 		ctx,
 		d.serviceMethod,

--- a/grpc/dispatcher.go
+++ b/grpc/dispatcher.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	encoding.RegisterCodec(FiberCodec{})
+	encoding.RegisterCodec(&FiberCodec{})
 }
 
 const (

--- a/grpc/dispatcher.go
+++ b/grpc/dispatcher.go
@@ -69,7 +69,7 @@ func (d *Dispatcher) Do(request fiber.Request) fiber.Response {
 		grpcRequest.Payload(),
 		response,
 		grpc.Header(&responseHeader),
-		grpc.CallContentSubtype(CodecName),
+		grpc.CallContentSubtype(codecName),
 	)
 	if err != nil {
 		// if ok is false, unknown codes.Unknown and Status msg is returned in Status

--- a/grpc/dispatcher.go
+++ b/grpc/dispatcher.go
@@ -113,7 +113,7 @@ func NewDispatcher(config DispatcherConfig) (*Dispatcher, error) {
 
 	dispatcher := &Dispatcher{
 		timeout:       configuredTimeout,
-		serviceMethod: fmt.Sprintf("%s/%s", config.Service, config.Method),
+		serviceMethod: fmt.Sprintf("/%s/%s", config.Service, config.Method),
 		endpoint:      config.Endpoint,
 		conn:          conn,
 	}

--- a/grpc/dispatcher.go
+++ b/grpc/dispatcher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+	"go.uber.org/zap/buffer"
 	"time"
 
 	"github.com/gojek/fiber"
@@ -13,16 +13,14 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protodesc"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
-	"google.golang.org/protobuf/types/descriptorpb"
-	"google.golang.org/protobuf/types/dynamicpb"
 )
+
+func init() {
+	encoding.RegisterCodec(FiberCodec{})
+}
 
 const (
 	TimeoutDefault = time.Second
@@ -36,8 +34,6 @@ type Dispatcher struct {
 	endpoint string
 	// conn is the grpc connection dialed upon creation of dispatcher
 	conn *grpc.ClientConn
-	// ResponseProto is the proto return type of the service.
-	responseProto proto.Message
 }
 
 type DispatcherConfig struct {
@@ -61,9 +57,16 @@ func (d *Dispatcher) Do(request fiber.Request) fiber.Response {
 	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, grpcRequest.Metadata)
 
-	responseProto := proto.Clone(d.responseProto)
+	response := new(buffer.Buffer)
 	var responseHeader metadata.MD
-	err := d.conn.Invoke(ctx, d.serviceMethod, grpcRequest.Payload(), responseProto, grpc.Header(&responseHeader))
+	err := d.conn.Invoke(
+		ctx,
+		d.serviceMethod,
+		grpcRequest.Payload(),
+		response,
+		grpc.Header(&responseHeader),
+		grpc.CallContentSubtype(CodecName),
+	)
 	if err != nil {
 		// if ok is false, unknown codes.Unknown and Status msg is returned in Status
 		responseStatus, _ := status.FromError(err)
@@ -76,7 +79,7 @@ func (d *Dispatcher) Do(request fiber.Request) fiber.Response {
 
 	return &Response{
 		Metadata: responseHeader,
-		Message:  responseProto,
+		Message:  response.Bytes(),
 		Status:   *status.New(codes.OK, "Success"),
 	}
 }
@@ -104,116 +107,11 @@ func NewDispatcher(config DispatcherConfig) (*Dispatcher, error) {
 			errors.New("grpc dispatcher: "+responseStatus.String()))
 	}
 
-	// Get reflection response from reflection server, which contain FileDescriptorProtos
-	reflectionResponse, err := getReflectionResponse(conn, config.Service)
-	if err != nil {
-		return nil, err
-	}
-	fileDescriptorProtoBytes := reflectionResponse.GetFileDescriptorResponse().GetFileDescriptorProto()
-
-	messageDescriptor, err := getMessageDescriptor(fileDescriptorProtoBytes, config.Service, config.Method)
-	if err != nil {
-		return nil, err
-	}
-
 	dispatcher := &Dispatcher{
 		timeout:       configuredTimeout,
 		serviceMethod: fmt.Sprintf("%s/%s", config.Service, config.Method),
 		endpoint:      config.Endpoint,
 		conn:          conn,
-		responseProto: dynamicpb.NewMessage(messageDescriptor),
 	}
 	return dispatcher, nil
-}
-
-func getReflectionResponse(conn *grpc.ClientConn, serviceName string) (*grpc_reflection_v1alpha.ServerReflectionResponse, error) {
-	// create a reflection client and get FileDescriptorProtos
-	reflectionClient := grpc_reflection_v1alpha.NewServerReflectionClient(conn)
-	req := &grpc_reflection_v1alpha.ServerReflectionRequest{
-		MessageRequest: &grpc_reflection_v1alpha.ServerReflectionRequest_FileContainingSymbol{
-			FileContainingSymbol: serviceName,
-		},
-	}
-	reflectionInfoClient, err := reflectionClient.ServerReflectionInfo(context.Background())
-	if err != nil {
-		return nil, fiberError.NewFiberError(
-			protocol.GRPC,
-			errors.New("grpc dispatcher: unable to get reflection information, ensure server reflection is enable and config are correct"))
-	}
-	if err = reflectionInfoClient.Send(req); err != nil {
-		return nil, fiberError.NewFiberError(protocol.GRPC, err)
-	}
-	reflectionResponse, err := reflectionInfoClient.Recv()
-	if err != nil {
-		return nil, fiberError.NewFiberError(protocol.GRPC, err)
-	}
-
-	return reflectionResponse, nil
-}
-
-func getMessageDescriptor(fileDescriptorProtoBytes [][]byte, serviceName string, methodName string) (protoreflect.MessageDescriptor, error) {
-	fileDescriptorProto, outputProtoName, err := getFileDescriptorProto(fileDescriptorProtoBytes, serviceName, methodName)
-	if err != nil {
-		return nil, err
-	}
-
-	messageDescriptor, err := getMessageDescriptorByName(fileDescriptorProto, outputProtoName)
-	if err != nil {
-		return nil, err
-	}
-	return messageDescriptor, nil
-}
-
-func getFileDescriptorProto(fileDescriptorProtoBytes [][]byte, serviceName string, methodName string) (*descriptorpb.FileDescriptorProto, string, error) {
-	var fileDescriptorProto *descriptorpb.FileDescriptorProto
-	var outputProtoName string
-
-	for _, fdpByte := range fileDescriptorProtoBytes {
-		fdp := &descriptorpb.FileDescriptorProto{}
-		if err := proto.Unmarshal(fdpByte, fdp); err != nil {
-			return nil, "", fiberError.NewFiberError(protocol.GRPC, err)
-		}
-
-		for _, service := range fdp.Service {
-			// find matching service descriptors from file descriptor
-			if serviceName == fmt.Sprintf("%s.%s", fdp.GetPackage(), service.GetName()) {
-				// find matching method from service descriptor
-				for _, method := range service.Method {
-					if method.GetName() == methodName {
-						outputType := method.GetOutputType()
-						//Get the proto name without package
-						outputProtoName = outputType[strings.LastIndex(outputType, ".")+1:]
-						fileDescriptorProto = fdp
-						break
-					}
-				}
-			}
-			if fileDescriptorProto != nil {
-				break
-			}
-		}
-		if fileDescriptorProto != nil {
-			break
-		}
-	}
-
-	if fileDescriptorProto == nil {
-		return nil, "", fiberError.NewFiberError(
-			protocol.GRPC,
-			errors.New("grpc dispatcher: unable to fetch file descriptors, ensure config are correct"))
-	}
-	return fileDescriptorProto, outputProtoName, nil
-}
-
-func getMessageDescriptorByName(fileDescriptorProto *descriptorpb.FileDescriptorProto, outputProtoName string) (protoreflect.MessageDescriptor, error) {
-	// Create a FileDescriptor from FileDescriptorProto, and get MessageDescriptor to create a dynamic message
-	// Note: It might be required to register new proto using protoregistry.Files.RegisterFile() at runtime
-	fileDescriptor, err := protodesc.NewFile(fileDescriptorProto, protoregistry.GlobalFiles)
-	if err != nil {
-		return nil, fiberError.NewFiberError(
-			protocol.GRPC,
-			errors.New("grpc dispatcher: unable to find proto in registry"))
-	}
-	messageDescriptor := fileDescriptor.Messages().ByName(protoreflect.Name(outputProtoName))
-	return messageDescriptor, nil
 }

--- a/grpc/dispatcher_test.go
+++ b/grpc/dispatcher_test.go
@@ -129,7 +129,7 @@ func TestNewDispatcher(t *testing.T) {
 			},
 			expected: &Dispatcher{
 				timeout:       time.Second * 5,
-				serviceMethod: fmt.Sprintf("%s/%s", service, method),
+				serviceMethod: fmt.Sprintf("/%s/%s", service, method),
 				endpoint:      fmt.Sprintf(":%d", port),
 			},
 		},

--- a/grpc/request.go
+++ b/grpc/request.go
@@ -4,20 +4,19 @@ import (
 	"github.com/gojek/fiber"
 	"github.com/gojek/fiber/protocol"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/protobuf/proto"
 )
 
 type Request struct {
 	// Metadata will hold the grpc headers for request
 	Metadata metadata.MD
-	Message  proto.Message
+	Message  []byte
 }
 
 func (r *Request) Protocol() protocol.Protocol {
 	return protocol.GRPC
 }
 
-func (r *Request) Payload() interface{} {
+func (r *Request) Payload() []byte {
 	return r.Message
 }
 

--- a/grpc/request.go
+++ b/grpc/request.go
@@ -25,9 +25,14 @@ func (r *Request) Header() map[string][]string {
 }
 
 func (r *Request) Clone() (fiber.Request, error) {
+	var copiedMessage []byte
+	if len(r.Message) > 0 {
+		copiedMessage = make([]byte, len(r.Message))
+		copy(copiedMessage, r.Message)
+	}
 	return &Request{
 		Metadata: r.Metadata,
-		Message:  r.Message,
+		Message:  copiedMessage,
 	}, nil
 }
 

--- a/grpc/request_test.go
+++ b/grpc/request_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/gojek/fiber"
-	testproto "github.com/gojek/fiber/internal/testdata/gen/testdata/proto"
 	"github.com/gojek/fiber/protocol"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
@@ -23,7 +22,7 @@ func TestRequest_Clone(t *testing.T) {
 			name: "simple",
 			req: &Request{
 				Metadata: metadata.New(map[string]string{"test": "1"}),
-				Message:  []byte{},
+				Message:  []byte("Testing"),
 			},
 		},
 	}
@@ -84,21 +83,21 @@ func TestRequest_OperationName(t *testing.T) {
 func TestRequest_Payload(t *testing.T) {
 
 	tests := []struct {
-		name string
-		req  Request
-		want interface{}
+		name     string
+		req      Request
+		expected []byte
 	}{
 		{
 			name: "ok payload",
 			req: Request{
-				Message: []byte{},
+				Message: []byte("Testing"),
 			},
-			want: &testproto.PredictValuesResponse{},
+			expected: []byte("Testing"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			//assert.True(t, proto.Equal(tt.want, tt.req.Payload()), "payload not equal to expected")
+			assert.Equal(t, tt.expected, tt.req.Payload())
 		})
 	}
 }

--- a/grpc/request_test.go
+++ b/grpc/request_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gojek/fiber/protocol"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestRequest_Clone(t *testing.T) {
@@ -24,7 +23,7 @@ func TestRequest_Clone(t *testing.T) {
 			name: "simple",
 			req: &Request{
 				Metadata: metadata.New(map[string]string{"test": "1"}),
-				Message:  &testproto.PredictValuesRequest{},
+				Message:  []byte{},
 			},
 		},
 	}
@@ -92,14 +91,14 @@ func TestRequest_Payload(t *testing.T) {
 		{
 			name: "ok payload",
 			req: Request{
-				Message: &testproto.PredictValuesResponse{},
+				Message: []byte{},
 			},
 			want: &testproto.PredictValuesResponse{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.True(t, proto.Equal(tt.want.(proto.Message), tt.req.Payload().(proto.Message)), "payload not equal to expected")
+			//assert.True(t, proto.Equal(tt.want, tt.req.Payload()), "payload not equal to expected")
 		})
 	}
 }

--- a/grpc/response.go
+++ b/grpc/response.go
@@ -7,12 +7,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 type Response struct {
 	Metadata metadata.MD
-	Message  proto.Message
+	Message  []byte
 	Status   status.Status
 }
 
@@ -20,7 +19,7 @@ func (r *Response) IsSuccess() bool {
 	return r.StatusCode() == int(codes.OK)
 }
 
-func (r *Response) Payload() interface{} {
+func (r *Response) Payload() []byte {
 	return r.Message
 }
 

--- a/grpc/response_test.go
+++ b/grpc/response_test.go
@@ -84,20 +84,19 @@ func TestResponse_Payload(t *testing.T) {
 	tests := []struct {
 		name     string
 		req      Response
-		expected interface{}
+		expected []byte
 	}{
 		{
 			name: "",
 			req: Response{
 				Message: responseByte,
 			},
-			expected: proto.Clone(response),
+			expected: responseByte,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			//assert.True(t,
-			//	proto.Equal(tt.expected.(proto.Message), tt.req.Payload().(proto.Message)), "actual payload not equal to expected")
+			assert.Equal(t, tt.expected, tt.req.Payload())
 		})
 	}
 }

--- a/grpc/response_test.go
+++ b/grpc/response_test.go
@@ -80,6 +80,7 @@ func TestResponse_Payload(t *testing.T) {
 		},
 		Metadata: nil,
 	}
+	responseByte, _ := proto.Marshal(response)
 	tests := []struct {
 		name     string
 		req      Response
@@ -88,15 +89,15 @@ func TestResponse_Payload(t *testing.T) {
 		{
 			name: "",
 			req: Response{
-				Message: response,
+				Message: responseByte,
 			},
 			expected: proto.Clone(response),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.True(t,
-				proto.Equal(tt.expected.(proto.Message), tt.req.Payload().(proto.Message)), "actual payload not equal to expected")
+			//assert.True(t,
+			//	proto.Equal(tt.expected.(proto.Message), tt.req.Payload().(proto.Message)), "actual payload not equal to expected")
 		})
 	}
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"time"
 
@@ -77,10 +76,6 @@ func (h *Handler) write(resp fiber.Response, writer http.ResponseWriter) (err er
 	}
 
 	writer.WriteHeader(resp.StatusCode())
-	bytePayLoad, ok := resp.Payload().([]byte)
-	if !ok {
-		return fiberErrors.NewFiberError(protocol.HTTP, errors.New("unable to parse payload"))
-	}
-	_, err = writer.Write(bytePayLoad)
+	_, err = writer.Write(resp.Payload())
 	return err
 }

--- a/http/request.go
+++ b/http/request.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -56,11 +55,7 @@ func NewHTTPRequest(req *http.Request) (*Request, error) {
 
 // Copy creates a deep copy of this request
 func (r *Request) Clone() (fiber.Request, error) {
-	bytePayLoad, ok := r.Payload().([]byte)
-	if !ok {
-		return nil, errors.New("unable to parse payload")
-	}
-	bodyReader := bytes.NewReader(bytePayLoad)
+	bodyReader := bytes.NewReader(r.Payload())
 
 	proxyRequest, err := http.NewRequest(r.Method, r.URL.String(), bodyReader)
 	if err != nil {

--- a/http/response_test.go
+++ b/http/response_test.go
@@ -85,7 +85,7 @@ func TestNewHTTPResponse(t *testing.T) {
 			resp := fiberHTTP.NewHTTPResponse(tt.response)
 
 			require.NotNil(t, resp)
-			require.Equal(t, string(tt.expected.payload), string(resp.Payload().([]byte)))
+			require.Equal(t, string(tt.expected.payload), string(resp.Payload()))
 			require.Equal(t, tt.expected.status, resp.StatusCode())
 			require.Equal(t, tt.expected.status/100 == 2, resp.IsSuccess())
 		})

--- a/request.go
+++ b/request.go
@@ -3,7 +3,7 @@ package fiber
 import "github.com/gojek/fiber/protocol"
 
 type Request interface {
-	Payload() interface{}
+	Payload() []byte
 	Header() map[string][]string
 	Clone() (Request, error)
 	OperationName() string

--- a/response.go
+++ b/response.go
@@ -7,7 +7,7 @@ import (
 
 type Response interface {
 	IsSuccess() bool
-	Payload() interface{}
+	Payload() []byte
 	StatusCode() int
 	BackendName() string
 	WithBackendName(string) Response


### PR DESCRIPTION
### Description
This MR seeks to improve the performance of grpc fiber by reducing proto marshalling overhead by using custom codec.

Fiber will no longer need to know the proto response of the `target routes`, any request sent to it will be expected to be in `[]byte`. User of Fiber would need to marshal their own proto into `Fiber.request`.

The byte responses of route will simply be wrapped in the response and the user of Fiber would be expected to unmarshal them into the final proto message.

The default proto codec enforces `proto.message` on both the request and respond proto. Using the custom codec, this enforcement is loosen for type allowed in the codedc and the marshaling is skipped, making the below connection invocation possible with non proto message.

```
err := d.conn.Invoke(
		ctx,
		d.serviceMethod,
		grpcRequest.Payload(),
		response,
		grpc.Header(&responseHeader),
		grpc.CallContentSubtype(CodecName),
	)
```

### Changes

- `response.go` and `request.go` - `Payload()` type changed from `interface{}` to `byte[]` 
-  `grpc/dispatcher.go` - Remove server reflection implementation 
- `grpc/codec.go` - codec implementation