### PR TITLE
merge proxy config of service and method together for grpc config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -178,15 +178,14 @@ func (c *CombinerConfig) initComponent() (fiber.Component, error) {
 // ProxyConfig is used to parse the configuration for a Proxy
 type ProxyConfig struct {
 	ComponentConfig
-	Endpoint string   `json:"endpoint" required:"true"`
-	Timeout  Duration `json:"timeout"`
-	Protocol string   `json:"protocol"`
+	Endpoint string            `json:"endpoint" required:"true"`
+	Timeout  Duration          `json:"timeout"`
+	Protocol protocol.Protocol `json:"protocol"`
 	GrpcConfig
 }
 
 type GrpcConfig struct {
-	Service string `json:"service,omitempty"`
-	Method  string `json:"method,omitempty"`
+	ServiceMethod string `json:"service_method,omitempty"`
 }
 
 func (c *ProxyConfig) initComponent() (fiber.Component, error) {
@@ -194,12 +193,11 @@ func (c *ProxyConfig) initComponent() (fiber.Component, error) {
 	var dispatcher fiber.Dispatcher
 	var err error
 	var backend fiber.Backend
-	if strings.EqualFold(c.Protocol, string(protocol.GRPC)) {
+	if strings.EqualFold(string(c.Protocol), string(protocol.GRPC)) {
 		dispatcher, err = grpc.NewDispatcher(grpc.DispatcherConfig{
-			Service:  c.Service,
-			Method:   c.Method,
-			Endpoint: c.Endpoint,
-			Timeout:  time.Duration(c.Timeout),
+			ServiceMethod: c.ServiceMethod,
+			Endpoint:      c.Endpoint,
+			Timeout:       time.Duration(c.Timeout),
 		})
 	} else {
 		httpClient := &http.Client{Timeout: time.Duration(c.Timeout)}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -85,10 +85,9 @@ func TestFromConfig(t *testing.T) {
 
 	grpcDispatcher, _ := fibergrpc.NewDispatcher(
 		fibergrpc.DispatcherConfig{
-			Service:  "testproto.UniversalPredictionService",
-			Method:   "PredictValues",
-			Endpoint: fmt.Sprintf("localhost:%d", port),
-			Timeout:  timeout,
+			ServiceMethod: "testproto.UniversalPredictionService/PredictValues",
+			Endpoint:      fmt.Sprintf("localhost:%d", port),
+			Timeout:       timeout,
 		})
 	grpcCaller, _ := fiber.NewCaller("proxy_name", grpcDispatcher)
 	grpcProxy := fiber.NewProxy(nil, grpcCaller)
@@ -112,7 +111,7 @@ func TestFromConfig(t *testing.T) {
 		{
 			name:           "grpc proxy",
 			configPath:     "../internal/testdata/config/invalid_grpc_proxy.yaml",
-			expectedErrMsg: "fiber: grpc dispatcher: missing config (endpoint/service/method)",
+			expectedErrMsg: "fiber: grpc dispatcher: missing config (endpoint/serviceMethod)",
 		},
 	}
 

--- a/example/simplegrpc/main.go
+++ b/example/simplegrpc/main.go
@@ -14,12 +14,11 @@ import (
 )
 
 const (
-	port1     = 50555
-	port2     = 50556
-	endpoint1 = "localhost:50555"
-	endpoint2 = "localhost:50556"
-	service   = "testproto.UniversalPredictionService"
-	method    = "PredictValues"
+	port1         = 50555
+	port2         = 50556
+	endpoint1     = "localhost:50555"
+	endpoint2     = "localhost:50556"
+	serviceMethod = "testproto.UniversalPredictionService/PredictValues"
 )
 
 func main() {
@@ -36,14 +35,12 @@ func main() {
 	component.SetStrategy(new(extras.RandomRoutingStrategy))
 
 	upiDispatcher1, _ := grpc.NewDispatcher(grpc.DispatcherConfig{
-		Endpoint: endpoint1,
-		Service:  service,
-		Method:   method,
+		Endpoint:      endpoint1,
+		ServiceMethod: serviceMethod,
 	})
 	upiDispatcher2, _ := grpc.NewDispatcher(grpc.DispatcherConfig{
-		Endpoint: endpoint2,
-		Service:  service,
-		Method:   method,
+		Endpoint:      endpoint2,
+		ServiceMethod: serviceMethod,
 	})
 
 	// Caller is required to work with combiner, fanout. Using a dispatcher plainly doesn't work

--- a/example/simplegrpcfromconfig/fiber.yaml
+++ b/example/simplegrpcfromconfig/fiber.yaml
@@ -7,13 +7,12 @@ routes:
     type: PROXY
     timeout: "20s"
     endpoint: "localhost:50555"
-    service: "testproto.UniversalPredictionService"
-    method: "PredictValues"
+    service_method: "testproto.UniversalPredictionService/PredictValues"
     protocol: "grpc"
   - id: route_b
     type: PROXY
     timeout: "40s"
     endpoint: "localhost:50556"
-    service: "testproto.UniversalPredictionService"
+    service_method: "testproto.UniversalPredictionService/PredictValues"
     method: "PredictValues"
     protocol: "grpc"

--- a/grpc/dispatcher_test.go
+++ b/grpc/dispatcher_test.go
@@ -24,9 +24,8 @@ import (
 )
 
 const (
-	port    = 50055
-	service = "testproto.UniversalPredictionService"
-	method  = "PredictValues"
+	port          = 50055
+	serviceMethod = "testproto.UniversalPredictionService/PredictValues"
 )
 
 var mockResponse *testproto.PredictValuesResponse
@@ -89,47 +88,33 @@ func TestNewDispatcher(t *testing.T) {
 		{
 			name: "empty endpoint",
 			dispatcherConfig: DispatcherConfig{
-				Service: service,
-				Method:  method,
+				ServiceMethod: serviceMethod,
 			},
 			expected: nil,
 			expectedErr: fiberError.ErrInvalidInput(
 				protocol.GRPC,
-				errors.New("grpc dispatcher: missing config (endpoint/service/method)")),
+				errors.New("grpc dispatcher: missing config (endpoint/serviceMethod)")),
 		},
 		{
-			name: "empty service",
+			name: "empty serviceMethod",
 			dispatcherConfig: DispatcherConfig{
-				Method:   method,
 				Endpoint: fmt.Sprintf(":%d", port),
 			},
 			expected: nil,
 			expectedErr: fiberError.ErrInvalidInput(
 				protocol.GRPC,
-				errors.New("grpc dispatcher: missing config (endpoint/service/method)")),
-		},
-		{
-			name: "empty method",
-			dispatcherConfig: DispatcherConfig{
-				Service:  service,
-				Endpoint: fmt.Sprintf(":%d", port),
-			},
-			expected: nil,
-			expectedErr: fiberError.ErrInvalidInput(
-				protocol.GRPC,
-				errors.New("grpc dispatcher: missing config (endpoint/service/method)")),
+				errors.New("grpc dispatcher: missing config (endpoint/serviceMethod)")),
 		},
 		{
 			name: "ok response",
 			dispatcherConfig: DispatcherConfig{
-				Service:  service,
-				Method:   method,
-				Endpoint: fmt.Sprintf(":%d", port),
-				Timeout:  time.Second * 5,
+				ServiceMethod: serviceMethod,
+				Endpoint:      fmt.Sprintf(":%d", port),
+				Timeout:       time.Second * 5,
 			},
 			expected: &Dispatcher{
 				timeout:       time.Second * 5,
-				serviceMethod: fmt.Sprintf("/%s/%s", service, method),
+				serviceMethod: fmt.Sprintf("/%s", serviceMethod),
 				endpoint:      fmt.Sprintf(":%d", port),
 			},
 		},
@@ -157,10 +142,9 @@ func TestNewDispatcher(t *testing.T) {
 
 func TestDispatcher_Do(t *testing.T) {
 	dispatcherConfig := DispatcherConfig{
-		Service:  service,
-		Method:   method,
-		Endpoint: fmt.Sprintf(":%d", port),
-		Timeout:  time.Second * 5,
+		ServiceMethod: serviceMethod,
+		Endpoint:      fmt.Sprintf(":%d", port),
+		Timeout:       time.Second * 5,
 	}
 	dispatcher, err := NewDispatcher(dispatcherConfig)
 	require.NoError(t, err, "unable to create dispatcher")

--- a/internal/testdata/config/grpc_proxy.yaml
+++ b/internal/testdata/config/grpc_proxy.yaml
@@ -3,5 +3,4 @@ id: proxy_name
 timeout: "20s"
 endpoint: "localhost:50555"
 protocol: "grpC" #intentional to test case-insensitivity
-service: "testproto.UniversalPredictionService"
-method: "PredictValues"
+service_method: "testproto.UniversalPredictionService/PredictValues"


### PR DESCRIPTION
### Description
Short PR to refactor `service` and `method` into `serviceMethod`.

Previously they were separated as the reflection server requests `service` only. Within `dispatcher`, they were concantenated, merging them bring consistency as well.

### Changes
fiber.yml before
```
service: "testproto.UniversalPredictionService"
method: "PredictValues"
```
fiber.yml after
```
service_method: "testproto.UniversalPredictionService/PredictValues"
```