### PR TITLE
Add ProtoMessage to fiber grpc Request

### DIFF
--- a/grpc/request.go
+++ b/grpc/request.go
@@ -25,15 +25,8 @@ func (r *Request) Header() map[string][]string {
 }
 
 func (r *Request) Clone() (fiber.Request, error) {
-	var copiedMessage []byte
-	if len(r.Message) > 0 {
-		copiedMessage = make([]byte, len(r.Message))
-		copy(copiedMessage, r.Message)
-	}
-	return &Request{
-		Metadata: r.Metadata,
-		Message:  copiedMessage,
-	}, nil
+	// for grpc, we'll just return itself (no cloning)
+	return r, nil
 }
 
 // OperationName is naming used in tracing interceptors

--- a/grpc/request.go
+++ b/grpc/request.go
@@ -4,12 +4,22 @@ import (
 	"github.com/gojek/fiber"
 	"github.com/gojek/fiber/protocol"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 )
 
 type Request struct {
 	// Metadata will hold the grpc headers for request
-	Metadata metadata.MD
-	Message  []byte
+	Metadata     metadata.MD
+	Message      []byte
+	ProtoMessage proto.Message
+}
+
+func NewRequest(metadata metadata.MD, msg []byte, protoMsg proto.Message) *Request {
+	return &Request{
+		Metadata:     metadata,
+		Message:      msg,
+		ProtoMessage: protoMsg,
+	}
 }
 
 func (r *Request) Protocol() protocol.Protocol {

--- a/grpc/request.go
+++ b/grpc/request.go
@@ -9,16 +9,16 @@ import (
 
 type Request struct {
 	// Metadata will hold the grpc headers for request
-	Metadata     metadata.MD
-	Message      []byte
-	ProtoMessage proto.Message
+	Metadata metadata.MD
+	Message  []byte
+	Proto    proto.Message
 }
 
 func NewRequest(metadata metadata.MD, msg []byte, protoMsg proto.Message) *Request {
 	return &Request{
-		Metadata:     metadata,
-		Message:      msg,
-		ProtoMessage: protoMsg,
+		Metadata: metadata,
+		Message:  msg,
+		Proto:    protoMsg,
 	}
 }
 
@@ -49,4 +49,8 @@ func (r *Request) OperationName() string {
 func (r *Request) Transform(_ fiber.Backend) (fiber.Request, error) {
 	// For grpc implementation, endpoint is init with dispatcher
 	return r, nil
+}
+
+func (r *Request) ProtoMessage() proto.Message {
+	return r.Proto
 }


### PR DESCRIPTION
This PR contains modification of:
1. Add `Proto` field and `ProtoMessage()` method to fiber grpc Request. This field is useful for fiber component that requires access to the protobuf object of the request without having to unmarshal from the `Message`
2. Grpc request `Clone` will return itself since no modification is performed in any fiber components